### PR TITLE
Loosen websocket-client requirement pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='mycroftapi',
     packages=['mycroftapi'],
-    install_requires=['websocket-client==0.44.0'],
+    install_requires=['websocket-client>=0.44.0'],
     version='2.0',
     description='a library to communicate with Mycroft API',
     author='Brian Hopkins',


### PR DESCRIPTION
- This library supports an integration in Home Assistant.
- The upcoming pip resolver will be more strict in resolving package version conflicts:
http://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html#what-will-change
- To avoid future issues it would be good if this library would change its pinning to allow any higher version and just set a minimum version.

Thanks for your support of Home Assistant!

NOTE: I HAVE NOT TESTED THIS CHANGE.